### PR TITLE
店舗情報のグローバルステート化と投稿作成画面への受け渡し。ナブバーの変更と現在地検索のデフォルト化 #1 #4

### DIFF
--- a/src/app/components/Post/Detail/index.tsx
+++ b/src/app/components/Post/Detail/index.tsx
@@ -1,8 +1,6 @@
 "use client";
-import Link from "next/link";
 import React, { FC, useState } from "react";
 import { AiFillTag, AiFillHeart } from "react-icons/ai";
-import { MdOutlineArrowBackIosNew } from "react-icons/md";
 import { CardHeader } from "../Card/Header";
 import Image from "next/image";
 import steak from "/public/steakcombo.jpeg";
@@ -11,24 +9,9 @@ import { DynamicModelViewer } from "../../ModelViewer/DynamicModelViewer";
 
 import { Mockdata } from "@/model/PostCard";
 import { Button } from "@/components/ui/button";
-
-type Props = {
-  restaurant: string;
-};
+import { PostNavbar } from "../../elements/Navbar/Back";
 
 const data = Mockdata;
-
-// 投稿詳細画面のナビゲーションバー
-export const PostNavbar: FC<Props> = (props) => {
-  return (
-    <nav className="navbar items-center justify-center relative">
-      <Link href="/" className="absolute z-1 left-2 top-4">
-        <MdOutlineArrowBackIosNew className="text-3xl text-black " />
-      </Link>
-      <h2 className="text-2xl italic font-bold">{props.restaurant}</h2>
-    </nav>
-  );
-};
 
 const PostDetail = () => {
   const [isLike, setIsLike] = useState(false);
@@ -43,7 +26,7 @@ const PostDetail = () => {
 
   return (
     <div>
-      <PostNavbar restaurant="8EIGHT BEEF" />
+      <PostNavbar name="8EIGHT BEEF" />
       <CardHeader {...data} />
 
       {/* 画像といいね */}

--- a/src/app/components/Shop/Item/index.tsx
+++ b/src/app/components/Shop/Item/index.tsx
@@ -1,0 +1,29 @@
+"use client";
+import React, { FC } from "react";
+import { useDispatch } from "react-redux";
+import { useRouter } from "next/navigation";
+import { Shop, setSelectedShop } from "@/store/features/shopSlice";
+
+type Props = {
+  shop: Shop;
+};
+
+// 店舗情報を表示するコンポーネント
+const ShopItem: FC<Props> = ({ shop }) => {
+  const dispatch = useDispatch(); // 店舗情報をセットする関数をshopSliceから取得
+  const router = useRouter();
+
+  // 店舗情報をセットする関数を実行し、店舗情報をセットする
+  const handleShopClick = () => {
+    dispatch(setSelectedShop(shop));
+    router.push("/post/new");
+  };
+
+  return (
+    <div key={shop.id} onClick={handleShopClick}>
+      <h2 className="text-lg py-2 font-bold">{shop.name}</h2>
+    </div>
+  );
+};
+
+export default ShopItem;

--- a/src/app/components/Shop/Search/index.tsx
+++ b/src/app/components/Shop/Search/index.tsx
@@ -3,7 +3,6 @@ import { usePathname, useRouter } from "next/navigation";
 import { FC, useState, ChangeEvent } from "react";
 import { AiOutlineSearch } from "react-icons/ai";
 import InputWithButton from "../../elements/InputButtonCombo";
-import { Button } from "@/components/ui/button";
 import useLocation from "./hooks/useLocation";
 import useQueryString from "./hooks/useQueryString";
 
@@ -38,17 +37,16 @@ export const SearchShop: FC = () => {
     pushToRouter({ keyword: searchText || undefined }); // キーワードを元にクエリパラメータを作成してrouter.pushする
   };
 
-  // 現在地付近の飲食店を検索する
-  const handlePushLocation = () => {
-    if (location) {
-      pushToRouter({
-        // クエリパラメータを作成してrouter.pushする
-        lat: location.lat.toString(), // 緯度
-        lng: location.lng.toString(), // 経度
-        range: "5", // 範囲
-      });
-    }
-  };
+  // レンダリング時に位置情報を取得しt、クエリパラメータを作成してrouter.pushする(初期値として現在地付近の飲食店を検索する)
+  // キーワード入力された場合は、キーワードを元にクエリパラメータを作成してrouter.pushする
+  // 位置情報が取得できなかった場合は、キーワードを元にクエリパラメータを作成してrouter.pushする
+  if (searchText === "" && location) {
+    pushToRouter({
+      lat: location.lat.toString(),
+      lng: location.lng.toString(),
+      range: "5",
+    });
+  }
 
   // 検索ボックスのprops
   const searchProps = {
@@ -68,12 +66,11 @@ export const SearchShop: FC = () => {
   return (
     <div className="flex flex-col lg:flex-nowrap justify-center pb-4 lg:justify-start">
       <InputWithButton {...searchProps}>検索</InputWithButton>
-      <Button
-        onClick={handlePushLocation}
-        className="rounded-md mt-4 bg-green-700 hover:bg-green-900 text-white container h-8 max-w-sm"
-      >
-        現在地付近の飲食店を検索する
-      </Button>
+      {searchText === "" && location && (
+        <div>
+          <p className="text-3lx text-gray-500 items-center">周辺の店舗情報</p>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/app/components/elements/Navbar/Back/index.tsx
+++ b/src/app/components/elements/Navbar/Back/index.tsx
@@ -1,19 +1,38 @@
+"use client";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { FC } from "react";
 import { MdOutlineArrowBackIosNew } from "react-icons/md";
 
 type Props = {
   name?: string;
+  isHome?: boolean;
 };
 
 //　投稿画面のナビゲーションバー
 export const PostNavbar: FC<Props> = (props) => {
+  const router = useRouter();
+
   return (
     <nav className="navbar items-center justify-center relative">
-      <Link href="/" className="absolute z-1 left-2 top-4">
-        <MdOutlineArrowBackIosNew className="text-3xl text-black " />
-      </Link>
-      <h2 className="text-2xl italic font-bold">{props.name}</h2>
+      {/* 戻るボタン */}
+      <div className="absolute z-1 left-2 top-4">
+        {props.isHome ? ( // isHomeがtrueの場合は、ホーム画面に戻る
+          <Link href="/">
+            <MdOutlineArrowBackIosNew className="text-3xl text-black" />
+          </Link>
+        ) : (
+          // isHomeがfalseの場合は、前の画面に戻る
+          <MdOutlineArrowBackIosNew
+            className="text-3xl text-black"
+            onClick={() => router.back()}
+          />
+        )}
+      </div>
+
+      <h2 className=" w-4/5 text-base text-center md:text-2xl italic font-bold truncate">
+        {props.name}
+      </h2>
     </nav>
   );
 };

--- a/src/app/components/elements/Navbar/Back/index.tsx
+++ b/src/app/components/elements/Navbar/Back/index.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+import { FC } from "react";
+import { MdOutlineArrowBackIosNew } from "react-icons/md";
+
+type Props = {
+  name?: string;
+};
+
+//　投稿画面のナビゲーションバー
+export const PostNavbar: FC<Props> = (props) => {
+  return (
+    <nav className="navbar items-center justify-center relative">
+      <Link href="/" className="absolute z-1 left-2 top-4">
+        <MdOutlineArrowBackIosNew className="text-3xl text-black " />
+      </Link>
+      <h2 className="text-2xl italic font-bold">{props.name}</h2>
+    </nav>
+  );
+};

--- a/src/app/components/elements/Navbar/index.tsx
+++ b/src/app/components/elements/Navbar/index.tsx
@@ -3,8 +3,6 @@ import React, { FC, useState } from "react";
 import user from "/public/penguin.jpeg";
 import Image from "next/image";
 import { GrLogin } from "react-icons/gr";
-import { AiOutlineSearch, AiOutlineHome } from "react-icons/ai";
-import Link from "next/link";
 
 type Props = {
   title: string;

--- a/src/app/post/new/page.tsx
+++ b/src/app/post/new/page.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { useSelector } from "react-redux";
+import { selectSelectedShop } from "@/store/features/shopSlice";
+import Link from "next/link";
+import { PostNavbar } from "@/app/components/elements/Navbar/Back";
+
+const NewPostPage = () => {
+  const selectedShop = useSelector(selectSelectedShop); // 選択された店舗情報を取得
+
+  return (
+    <div>
+      {/*店舗が選択されている場合はNavbarに店舗名を表示*/}
+      <PostNavbar name={`店舗名：${selectedShop?.name}`} />
+      {/*店舗が選択されている場合は店舗情報を表示 */}
+      {selectedShop ? (
+        // 店舗名
+        <div>
+          <p className="text-lg py-2">店舗名: {selectedShop.name}</p>
+          {/* 店舗の住所 */}
+          <p className="text-lg py-2">住所: {selectedShop.address}</p>
+          <Link href={selectedShop.urls.pc} className="text-lg py-2">
+            公式サイト
+          </Link>
+        </div>
+      ) : (
+        <p className="text-lg py-2">No Shop Selected</p>
+      )}
+    </div>
+  );
+};
+
+export default NewPostPage;

--- a/src/app/post/search/page.tsx
+++ b/src/app/post/search/page.tsx
@@ -1,5 +1,8 @@
+import ShopItem from "@/app/components/Shop/Item";
 import { SearchShop } from "@/app/components/Shop/Search";
 import Navbar from "@/app/components/elements/Navbar";
+import { PostNavbar } from "@/app/components/elements/Navbar/Back";
+import { Shop } from "@/store/features/shopSlice";
 
 interface SearchParams {
   keyword?: string;
@@ -37,15 +40,13 @@ export default async function SearchShopPage({
 
     return (
       <div>
-        <Navbar title="店舗検索" />
-        <div className="p-8">
+        <PostNavbar />
+        <div className="flex flex-col justify-center items-center p-8">
           <SearchShop />
           <div>
             {shops?.length ? (
-              shops.map((shop: any, index: number) => (
-                <div key={shop.id || index}>
-                  <h2 className="text-lg py-2 font-bold">{shop.name}</h2>
-                </div>
+              shops.map((shop: Shop, index: number) => (
+                <ShopItem key={shop.id || index} shop={shop} />
               ))
             ) : (
               <p>検索結果に当てはまりませんでした</p>

--- a/src/app/post/search/page.tsx
+++ b/src/app/post/search/page.tsx
@@ -40,7 +40,7 @@ export default async function SearchShopPage({
 
     return (
       <div>
-        <PostNavbar />
+        <PostNavbar isHome />
         <div className="flex flex-col justify-center items-center p-8">
           <SearchShop />
           <div>

--- a/src/store/features/shopSlice.ts
+++ b/src/store/features/shopSlice.ts
@@ -8,7 +8,9 @@ export interface Shop {
   lat: number; // 緯度
   lng: number; // 経度
   imageUr?: string; // 店舗画像
-  urls: string; // 店舗のURL
+  urls: {
+    pc: string; // PC版のURL
+  };
 }
 
 interface ShopState {

--- a/src/store/features/shopSlice.ts
+++ b/src/store/features/shopSlice.ts
@@ -1,0 +1,44 @@
+import { PayloadAction, createSlice } from "@reduxjs/toolkit";
+
+// ここで型を定義する
+export interface Shop {
+  id: number; // 店舗ID
+  name: string; // 店舗名
+  address: string; // 住所
+  lat: number; // 緯度
+  lng: number; // 経度
+  imageUr?: string; // 店舗画像
+  urls: string; // 店舗のURL
+}
+
+interface ShopState {
+  selectedShop: Shop | null;
+}
+
+const initialState: ShopState = {
+  selectedShop: null,
+};
+
+// 店舗情報を管理する
+export const shopSlice = createSlice({
+  name: "shop", // sliceの名前
+  initialState,
+  reducers: {
+    // reducerの定義(選択された店舗情報をセットする)
+    setSelectedShop: (state, action: PayloadAction<Shop | null>) => {
+      state.selectedShop = action.payload;
+    },
+  },
+});
+
+// action creator(Stateに対して何かを行う関数)
+export const { setSelectedShop } = shopSlice.actions; // action creator(選択された店舗情報をセットする)
+
+interface RootState {
+  // RootStateの型を定義する
+  shop: ShopState;
+}
+
+export const selectSelectedShop = (state: RootState) => state.shop.selectedShop; // selector(選択された店舗情報を取得する)
+
+export default shopSlice.reducer; // reducer

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -1,7 +1,9 @@
 import { configureStore } from "@reduxjs/toolkit";
+import shopReducer from "./features/shopSlice";
 
 export const store = configureStore({
   reducer: {
+    shop: shopReducer,
     // reducerをここに追加
   },
   devTools: process.env.NODE_ENV !== "production", //　開発環境のみ有効


### PR DESCRIPTION
### 店舗情報のグローバル化
店舗検索で選択した店舗情報を投稿作成画面に渡すため、shopSliceを作成し、管理

### 投稿作成画面(仮)
上記のstateを受け取り、店舗情報を表示する

### Navbarの変更
前の画面に戻るためのNavbar作成
表示させたいタイトルがある場合は、propsで渡すように
props(isHome)によって、1つ前のページに戻るか、ホームに戻るかを制御

### 店舗検索の初回レンダリング時に現在地でfeatchするように
キーワードが未入力で、現在地が取得できている場合に、クエリパラメーターを渡すように