### PR TITLE
MyProfile画面のUI作成(part1) #1 #9

### DIFF
--- a/src/app/components/Profile/Header/index.tsx
+++ b/src/app/components/Profile/Header/index.tsx
@@ -3,28 +3,23 @@ import React, { FC } from "react";
 
 import { Profile } from "@/types/Profile/types";
 
-type Props = {
-  profile: Profile;
-  contents?: any; // ここにcontents(post, like, model)を追加
-};
-
-const ProfileHeader: FC<Props> = (props) => {
+const ProfileHeader: FC<Profile> = (profile) => {
   return (
-    <div className="max-w-6xl pl-2 py-4">
+    <div className="max-w-6xl pl-4 py-8">
       <div className="flex">
         {/* avatar画像 */}
         <div className="">
           <Image
-            src={props.profile.img}
+            src={profile.img}
             alt="steak"
             width={200}
             height={200}
-            className="rounded-full w-24 h-24"
+            className="rounded-full w-28 h-28 sm:w-40 md:h-40"
           />
         </div>
 
         {/* 投稿数・フォローフォロワー*/}
-        <div className="flex  pt-6  px-4">
+        <div className="flex justify-center pt-6  px-4">
           {/* 投稿数 */}
           <div className="flex flex-col items-center px-4">
             <h2 className="font-bold text-lg">1</h2>
@@ -32,16 +27,12 @@ const ProfileHeader: FC<Props> = (props) => {
           </div>
           {/* フォロー数 */}
           <div className="flex flex-col items-center px-4">
-            <h2 className="font-bold text-lg">
-              {props.profile.followings.length}
-            </h2>
+            <h2 className="font-bold text-lg">{profile.followings.length}</h2>
             <h2 className="font-thin text-xs text-gray-500">フォロー</h2>
           </div>
           {/* フォロワー数 */}
           <div className="flex flex-col items-center">
-            <h2 className="font-bold text-lg">
-              {props.profile.followers.length}
-            </h2>
+            <h2 className="font-bold text-lg">{profile.followers.length}</h2>
             <h2 className=" font-thin text-xs text-gray-500">フォロワー</h2>
           </div>
         </div>

--- a/src/app/components/Profile/Header/index.tsx
+++ b/src/app/components/Profile/Header/index.tsx
@@ -1,0 +1,29 @@
+import Image from "next/image";
+import React, { FC } from "react";
+
+import { Profile } from "@/types/Profile/types";
+
+type Props = {
+  profile: Profile;
+};
+
+const ProfileHeader: FC<Props> = (props) => {
+  return (
+    <div className="max-w-6xl p-4">
+      <div className="grid grid-cols-3 gap-4">
+        {/* avatar画像 */}
+        <div className="col-span-1">
+          <Image
+            src={props.profile.img}
+            alt="steak"
+            width={200}
+            height={200}
+            className="rounded-full w-20 h-20"
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProfileHeader;

--- a/src/app/components/Profile/Header/index.tsx
+++ b/src/app/components/Profile/Header/index.tsx
@@ -5,22 +5,48 @@ import { Profile } from "@/types/Profile/types";
 
 type Props = {
   profile: Profile;
+  contents?: any; // ここにcontents(post, like, model)を追加
 };
 
 const ProfileHeader: FC<Props> = (props) => {
   return (
-    <div className="max-w-6xl p-4">
-      <div className="grid grid-cols-3 gap-4">
+    <div className="max-w-6xl pl-2 py-4">
+      <div className="flex">
         {/* avatar画像 */}
-        <div className="col-span-1">
+        <div className="">
           <Image
             src={props.profile.img}
             alt="steak"
             width={200}
             height={200}
-            className="rounded-full w-20 h-20"
+            className="rounded-full w-24 h-24"
           />
         </div>
+
+        {/* 投稿数・フォローフォロワー*/}
+        <div className="flex  pt-6  px-4">
+          {/* 投稿数 */}
+          <div className="flex flex-col items-center px-4">
+            <h2 className="font-bold text-lg">1</h2>
+            <h2 className="font-thin text-xs text-gray-500">投稿</h2>
+          </div>
+          {/* フォロー数 */}
+          <div className="flex flex-col items-center px-4">
+            <h2 className="font-bold text-lg">
+              {props.profile.followings.length}
+            </h2>
+            <h2 className="font-thin text-xs text-gray-500">フォロー</h2>
+          </div>
+          {/* フォロワー数 */}
+          <div className="flex flex-col items-center">
+            <h2 className="font-bold text-lg">
+              {props.profile.followers.length}
+            </h2>
+            <h2 className=" font-thin text-xs text-gray-500">フォロワー</h2>
+          </div>
+        </div>
+
+        {/*  */}
       </div>
     </div>
   );

--- a/src/app/components/Profile/Post/index.tsx
+++ b/src/app/components/Profile/Post/index.tsx
@@ -1,0 +1,35 @@
+import { tPostCard } from "@/types/Post/types";
+import Image from "next/image";
+import React, { FC } from "react";
+import { AiFillHeart } from "react-icons/ai";
+import { MdComment } from "react-icons/md";
+
+const ProfilePost: FC<tPostCard> = (post) => {
+  return (
+    <div className="pl-4 pt-2 grid grid-cols-3 gap-2">
+      <div className="relative group">
+        {/* 画像 */}
+        <Image
+          src={post.image}
+          alt="post"
+          width={200}
+          height={200}
+          className=" absolute object-cover rounded-lg w-28 h-28"
+        />
+        {/* いいね、コメント */}
+        <div className="absolute top-1 left-1 bg-gray-200 z-10 w-full justify-evenly items-center h-full  bg-black-faded group-hover:flex group-hover:top-16">
+          <p className=" text-xs flex items--center text-white font-bold">
+            <AiFillHeart className="text-sm text-red-400" />
+            <span>100</span>
+          </p>
+          <p className=" text-xs flex items-center text-white font-bold">
+            <MdComment className="text-sm text-white " />
+            <span>100</span>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProfilePost;

--- a/src/app/components/Profile/TabBar/index.tsx
+++ b/src/app/components/Profile/TabBar/index.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { AiFillHeart } from "react-icons/ai";
+import { PiNotebookBold } from "react-icons/pi";
+
+const ProfileTabBar = () => {
+  return (
+    <div>
+      {/* 切り替えコンテンツ */}
+      <div className="flex justify-center gap-24">
+        <button className="flex justify-center items-center border-gray-800 py-2 text-sm font-semibold gap-2 text-gray-400 focus:text-gray-600 focus:border-b">
+          <PiNotebookBold className="text-3xl" />
+          投稿
+        </button>
+        <button className="flex justify-center items-center border-gray-800 py-2 text-sm font-semibold gap-2 text-gray-400 focus:text-gray-600 focus:border-b">
+          <AiFillHeart className="text-3xl" />
+          いいね
+        </button>
+      </div>
+      {/* 軸 */}
+      <div className="border border-gray-400 bottom-1  mx-4" />
+    </div>
+  );
+};
+
+export default ProfileTabBar;

--- a/src/app/components/Profile/index.tsx
+++ b/src/app/components/Profile/index.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from "react";
 import ProfileHeader from "./Header";
 import { Profile } from "@/types/Profile/types";
+import TabBar from "./TabBar";
 
 type Props = {
   profile: Profile;
@@ -8,7 +9,12 @@ type Props = {
 };
 
 const Profile: FC<Props> = (props) => {
-  return <ProfileHeader {...props} />;
+  return (
+    <div>
+      <ProfileHeader {...props} />
+      <TabBar />
+    </div>
+  );
 };
 
 export default Profile;

--- a/src/app/components/Profile/index.tsx
+++ b/src/app/components/Profile/index.tsx
@@ -1,0 +1,14 @@
+import React, { FC } from "react";
+import ProfileHeader from "./Header";
+import { Profile } from "@/types/Profile/types";
+
+type Props = {
+  profile: Profile;
+  contents?: any; // ここにcontents(post, like, model)を追加
+};
+
+const Profile: FC<Props> = (props) => {
+  return <ProfileHeader {...props} />;
+};
+
+export default Profile;

--- a/src/app/components/Profile/index.tsx
+++ b/src/app/components/Profile/index.tsx
@@ -2,17 +2,20 @@ import React, { FC } from "react";
 import ProfileHeader from "./Header";
 import { Profile } from "@/types/Profile/types";
 import TabBar from "./TabBar";
+import ProfilePost from "./Post";
+import { tPostCard } from "@/types/Post/types";
 
 type Props = {
   profile: Profile;
-  contents?: any; // ここにcontents(post, like, model)を追加
+  post: tPostCard; // ここにcontents(post, like, model)を追加
 };
 
 const Profile: FC<Props> = (props) => {
   return (
     <div>
-      <ProfileHeader {...props} />
+      <ProfileHeader {...props.profile} />
       <TabBar />
+      <ProfilePost {...props.post} />
     </div>
   );
 };

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -2,14 +2,21 @@ import React from "react";
 import { PostNavbar } from "../components/elements/Navbar/Back";
 import Profile from "../components/Profile";
 import { mockProfileData } from "@/model/Profile";
+import { PostCardModel } from "@/model/PostCard";
 
 const profile = mockProfileData; // モックデータを取得
+const post = PostCardModel; // モックデータを取得
+
+const contents = {
+  profile,
+  post,
+};
 
 const MyProfilePage = () => {
   return (
     <div>
       <PostNavbar name={profile.nickName} />
-      <Profile profile={profile} />
+      <Profile {...contents} />
     </div>
   );
 };

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { PostNavbar } from "../components/elements/Navbar/Back";
+import Profile from "../components/Profile";
+import { mockProfileData } from "@/model/Profile";
+
+const profile = mockProfileData; // モックデータを取得
+
+const MyProfilePage = () => {
+  return (
+    <div>
+      <PostNavbar />
+      <Profile profile={profile} />
+    </div>
+  );
+};
+
+export default MyProfilePage;

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -8,7 +8,7 @@ const profile = mockProfileData; // モックデータを取得
 const MyProfilePage = () => {
   return (
     <div>
-      <PostNavbar />
+      <PostNavbar name={profile.nickName} />
       <Profile profile={profile} />
     </div>
   );

--- a/src/model/PostCard.ts
+++ b/src/model/PostCard.ts
@@ -6,7 +6,7 @@ import { Author, Restaurant, tPostCard } from "@/types/Post/types";
 export const AuthorModel: Author = {
   id: 1,
   nickName: "ふくえもん",
-  avatarImg: { user },
+  avatarImg: user,
 };
 
 export const RestaurantModel: Restaurant = {

--- a/src/model/PostCard.ts
+++ b/src/model/PostCard.ts
@@ -21,7 +21,7 @@ export const PostCardModel: tPostCard = {
   restaurant: RestaurantModel,
   createdAt: "2023-05-26",
   menu: "ステーキコンボ",
-  image: { steak },
+  image: steak,
   model: "steakcombo.glb",
   author: AuthorModel,
 };

--- a/src/model/Profile.ts
+++ b/src/model/Profile.ts
@@ -5,7 +5,7 @@ export const mockProfileData: Profile = {
   nickName: "ふくえもん",
   userProfile: 12345,
   created_on: "2023-01-01",
-  img: { user },
+  img: user,
   followings: [
     {
       nickName: "Alice",

--- a/src/types/Post/types.ts
+++ b/src/types/Post/types.ts
@@ -4,7 +4,7 @@ import { StaticImageData } from "next/image";
 export type Author = {
   id: number;
   nickName: string;
-  avatarImg: string | object;
+  avatarImg: StaticImageData;
 };
 
 export type Restaurant = {
@@ -19,7 +19,7 @@ export type tPostCard = {
   restaurant: Restaurant;
   createdAt: string;
   menu: string;
-  image?: StaticImageData;
+  image: StaticImageData;
   model?: File | string;
   author: Author;
 };

--- a/src/types/Post/types.ts
+++ b/src/types/Post/types.ts
@@ -1,3 +1,5 @@
+import { StaticImageData } from "next/image";
+
 // Type (PostCard)
 export type Author = {
   id: number;
@@ -17,7 +19,7 @@ export type tPostCard = {
   restaurant: Restaurant;
   createdAt: string;
   menu: string;
-  image: File | object;
+  image?: StaticImageData;
   model?: File | string;
   author: Author;
 };

--- a/src/types/Profile/types.ts
+++ b/src/types/Profile/types.ts
@@ -1,10 +1,12 @@
 // Profileの型定義
 
+import { StaticImageData } from "next/image";
+
 export interface Profile {
   nickName: string;
   userProfile: number;
   created_on?: string;
-  img?: string | object;
+  img: StaticImageData;
   followings: Follow[];
   followers: Follow[];
 }


### PR DESCRIPTION
### やったこと
- 型定義と仮データの変更

- MyProfile画面

- mockデータを活用して、propsで画面のパーツごとに作成していく

### Profile/Header

---

Profile情報を受け取る

左側にアバター画像・右側に投稿数・フォローフォロワーを表示するように

(profile.folower.length)で数を取得

(postの数も表示できるように)

**(今後)**

投稿数を取得するために、データの数を取得する方法を考える

### Profile/Post

---

ユーザーのProfile情報に基づいた投稿データを受け取る

**(今後)**

id→Linkにセットし、投稿詳細画面へ遷移できるように

propsは各コンポーネントで、必要なものだけを受け取るように